### PR TITLE
Add support for additional attributes.

### DIFF
--- a/test/test_rubeepass.rb
+++ b/test/test_rubeepass.rb
@@ -85,4 +85,10 @@ class RPassTest < Minitest::Test
         assert_equal("facebook_password", @facebook.password)
         assert_equal("google_password", @google.password)
     end
+
+    def test_attributes
+        assert(@chase.has_attribute?("Password"))
+        assert_equal(@chase.password, @chase.attribute("Password"))
+        assert_equal(@chase.password, @chase.attributes["Password"])
+    end
 end


### PR DESCRIPTION
The KDBX 3.1 schema doesn't discriminate against additional attributes. Basically, the XML structure of an entry looks like:

```xml
<String>
  <Key>Notes</Key>
  <Value/>
</String>
<String>
  <Key>Password</Key>
  <Value Protected="True">A4lbRXBnNZCWn44ALQ==</Value>
</String>
<String>
  <Key>Title</Key>
  <Value>test-title</Value>
</String>
<String>
  <Key>URL</Key>
  <Value/>
</String>
<String>
  <Key>UserName</Key>
  <Value>test-username</Value>
</String>
<String>
  <Key>protected-attribute</Key>
  <Value Protected="True">a4kOfEWA04P1URIYxe4eJ81jqcUNZNdozxkQineJ</Value>
</String>
<String>
  <Key>test-attribute</Key>
  <Value>test-attribute-value</Value>
</String>
```

It's the client who's giving Notes, Password, Title, URL, and UserName special meaning. This PR adds support for reading the additional (i.e arbitrary) attributes.

Considering the above schema, I have made the implementation to be much more generic which means I've removed quite a lot of code duplication:

 * the case statement from `Entry::from_xml` is gone as all the attributes are handled in a generic way
 * theres a bunch of new methods for handling this information:
   * `Entry#has_attribute?(attr)` - returns whether the named attribute exist in an entry
   * `Entry#attribute(attr)` - returns the attribute, tries to use `ProtectedDecryptor#get_password`, otherwise it returns the actual value. For compatibility reasons with your implementation of `Entry#notes`, `Entry#password`, `Entry#title`, `Entry#url`, or `Entry#username`, it returns an empty string when `Entry#has_attribute?(attr)` returns false.
   * `Entry#attributes` - basically calls the above attribute method for all attribute keys and returns a decrypted list of attributes
 * `@notes`, `@password`, `@title`, `@url`, `@username` declared in the `Entry` constructor now simply reuse the attribute method and they are exposed as `attr_accessor`
 * minor changes to use `@password` instead of `Entry#password` inside `Entry` as now the instance attributes hold the decrypted value rather than the index to `@ciphertext` of `ProtectedDecryptor`